### PR TITLE
fixes lw executing more parallel workers than specified

### DIFF
--- a/littleworkers.py
+++ b/littleworkers.py
@@ -173,7 +173,7 @@ class Pool(object):
         while keep_running:
             self.inspect_pool()
 
-            if len(self.pool) <= min(self.command_count(), self.workers):
+            if (len(self.pool) < self.workers) and (self.command_count() > 0):
                 command = self.next_command()
 
                 if not command:


### PR DESCRIPTION
If the command count > the number of workers + 2, lw limits the number of workers to the specified number + 1.

e.g.
worker count: 2
commands: ["sleep 10", "sleep 11", "sleep 12", "sleep 13"]
previous behavior:

```
# no commands executing
DEBUG:root:len(pool): '0', command_count: '4', workers: '2', min: '2'
# first command started
DEBUG:root:len(pool): '1', command_count: '3', workers: '2', min: '2'
# second command started
DEBUG:root:len(pool): '2', command_count: '2', workers: '2', min: '2'
# third command started
DEBUG:root:len(pool): '3', command_count: '1', workers: '2', min: '1'
#3 commands executing
# first command finishes
DEBUG:root:len(pool): '2', command_count: '1', workers: '2', min: '1'
# second command finishes
DEBUG:root:len(pool): '1', command_count: '1', workers: '2', min: '1'
# fourth command started
DEBUG:root:len(pool): '2', command_count: '0', workers: '2', min: '0'
# third command finishes
DEBUG:root:len(pool): '1', command_count: '0', workers: '2', min: '0'
```

new behavior:

```
# no commands executing
DEBUG:root:len(pool): '0', command_count: '4', workers: '2'
# first command started
DEBUG:root:len(pool): '1', command_count: '3', workers: '2'
# seconds command started
DEBUG:root:len(pool): '2', command_count: '2', workers: '2'
#2 commands executing
# first command finishes
DEBUG:root:len(pool): '1', command_count: '2', workers: '2'
# third command started
DEBUG:root:len(pool): '2', command_count: '1', workers: '2'
# second command finishes
DEBUG:root:len(pool): '1', command_count: '1', workers: '2',
# fourth command started
DEBUG:root:len(pool): '2', command_count: '0', workers: '2'
```
